### PR TITLE
Convert tight lists to loose lists in slides for pandoc PDF rendering

### DIFF
--- a/slides/block_00_syllabus_logistics.md
+++ b/slides/block_00_syllabus_logistics.md
@@ -25,7 +25,9 @@ January 8, 2026
 **Eduardo Arino de la Rubia** (rubiae@ceu.edu)
 
 - Senior Director of Data Science, Meta
+
 - Chief Data Scientist, Domino Data Lab (pre-seed → Series B, Sequoia)
+
 - Principal Data Scientist, Ingram
 
 Based in southern Spain.
@@ -113,8 +115,11 @@ No surprises. Each component connects to what we learn.
 
 You'll receive a 2-page business scenario describing:
 - A company and its situation
+
 - A business problem
+
 - Key stakeholders
+
 - Available data
 
 Your job: Scope it professionally using the Brief framework.
@@ -171,7 +176,9 @@ We'll cover the key concepts in class.
 Available in the course repository:
 
 - `templates/analytics_project_brief.md` — Blank template
+
 - `templates/examples/` — 9 worked examples (one per analysis)
+
 - `scenarios/` — Your assignment scenario (distributed individually)
 
 **Location:** QS B-421
@@ -184,7 +191,9 @@ Available in the course repository:
 
 **AI Usage:**
 - ✅ Brainstorm, draft, code you understand
+
 - ✅ Add "AI Usage" note describing what you used
+
 - ❌ Submit unedited AI-generated work
 
 **Academic Integrity:** Cheating is not negotiable.

--- a/slides/block_01_analytics_project_brief.md
+++ b/slides/block_01_analytics_project_brief.md
@@ -32,7 +32,9 @@ January 8, 2026
 Before we dive in:
 
 - Grab coffee if you need it
+
 - Phones away (you'll want to focus)
+
 - We'll take breaks — this is a marathon, not a sprint
 
 <!--
@@ -99,8 +101,11 @@ A: Great question. That's exactly what we're going to learn today. Spoiler: they
 It's rarely the model. It's usually:
 
 - **Wrong problem** — solved something nobody needed
+
 - **Wrong metric** — optimized the wrong thing
+
 - **Wrong stakeholders** — built it, nobody used it
+
 - **Wrong scope** — took too long, world moved on
 
 This course is about avoiding those failures.
@@ -292,8 +297,11 @@ A: The specific format is mine, but the questions are universal. Every good PM, 
 By the end of this course, you will be able to:
 
 1. **Use the Analytics Project Brief** to scope projects
+
 2. **Identify counter-metrics** and stakeholder dynamics
+
 3. **Recognize which analyses** apply to different problems
+
 4. **Apply influence strategies** to gain buy-in
 
 <!--
@@ -533,7 +541,9 @@ The most important section. Everything flows from here.
 
 **Three questions to answer:**
 1. What business question will this analysis inform?
+
 2. Who is asking, and why now?
+
 3. Who is the ultimate decision maker?
 
 <!--
@@ -848,7 +858,9 @@ Beyond the grid, identify:
 
 The "why" matters. People block for reasons:
 - Threatens their budget
+
 - Makes their past work look bad
+
 - Creates work for their team
 
 <!--
@@ -989,12 +1001,16 @@ Be explicit about what's **in** and **out**:
 
 **In Scope:**
 - US market only
+
 - Last 6 months of data
+
 - Desktop and mobile web
 
 **Out of Scope:**
 - Native app (separate project)
+
 - International markets
+
 - Real-time implementation
 
 <!--
@@ -1027,10 +1043,12 @@ A: Point to the Brief. 'We agreed this was out of scope. We can add it, but let'
 
 **Analytical success:** What makes the analysis itself good?
 - Metric defined with <20% confidence interval
+
 - 3+ statistically significant drivers identified
 
 **Business success:** What makes it valuable?
 - Product team changes roadmap based on findings
+
 - Clear A/B test hypotheses generated
 
 <!--
@@ -1473,9 +1491,13 @@ A: Ideally, stakeholders decide with your input. You bring the options; they dec
 Five questions to find counter-metrics:
 
 1. **Direct negative:** What directly worsens when X improves?
+
 2. **Quality degradation:** What quality suffers?
+
 3. **User segments:** Which users are harmed?
+
 4. **Temporal tradeoffs:** What long-term metrics suffer?
+
 5. **Cross-functional:** Whose goals are threatened?
 
 <!--
@@ -1514,8 +1536,11 @@ A: No. You need 2-3 total, from whichever categories are most relevant. But chec
 
 **What breaks?**
 1. Revenue per order (people buy cheaper stuff to "just finish")
+
 2. Return rate (impulse purchases get returned)
+
 3. Customer service load (confused customers)
+
 4. Fraud rate (less friction = more fraud)
 
 <!--
@@ -1551,8 +1576,11 @@ Four counter-metrics, each with a causal story. That's the level of thinking I w
 
 **What breaks?**
 1. Notification opt-out rate (annoy people → they disable)
+
 2. App uninstalls (too many notifications → rage quit)
+
 3. Session quality (clicked but didn't engage)
+
 4. User trust (feels spammy → brand damage)
 
 <!--
@@ -1671,11 +1699,14 @@ A: Challenge yourself: are they all equally critical? Usually, 2-3 are existenti
 
 **Guardrail:** Hard stop. If this worsens, kill the project.
 - Fraud rate
+
 - Data quality
+
 - Legal compliance
 
 **Tradeoff:** Acceptable within bounds. Monitor but don't stop.
 - Short-term revenue (if LTV improves)
+
 - Complexity (if value justifies it)
 
 Label each counter-metric as one or the other.
@@ -1716,7 +1747,9 @@ Now let's practice.
 
 **Exercise (5 min):**
 1. Individually, write a pre-mortem (2-3 sentences)
+
 2. What went wrong? Be specific.
+
 3. What counter-metric would have caught this?
 
 <!--
@@ -1809,7 +1842,9 @@ INSTRUCTOR NOTE:
 Psychology research shows:
 
 - **Prospective hindsight** increases ability to identify reasons for outcomes by 30%
+
 - Easier to generate specific failures than abstract risks
+
 - Creates psychological safety to name concerns
 
 It's not pessimism. It's **preparation**.
@@ -1846,9 +1881,13 @@ This isn't pessimism. It's strategic imagination. You're not hoping for failure 
 ## Key Takeaways: Counter-Metrics
 
 1. **Every metric optimization breaks something else**
+
 2. **Use the "What Breaks" framework** to find counter-metrics
+
 3. **Identify 2-3** — not zero, not twenty
+
 4. **Label as Guardrail or Tradeoff**
+
 5. **Pre-mortem** surfaces risks you'd otherwise miss
 
 <!--

--- a/slides/block_02_acquisition_analyses.md
+++ b/slides/block_02_acquisition_analyses.md
@@ -42,7 +42,9 @@ Today we cover 9 foundational analyses. You won't memorize them all—and you sh
 
 **Your goal:**
 1. Know what each analysis answers conceptually
+
 2. Recognize which one applies to a given problem
+
 3. Know where to find the detailed example when you need it
 
 Each analysis has a complete Brief example in `templates/examples/`. Use them.
@@ -290,6 +292,7 @@ A: Usually users, to avoid double-counting the same person who abandons and retu
 
 Two ways to view:
 - **Percentage view:** Which step has the worst conversion rate?
+
 - **Absolute view:** Which step loses the most users?
 
 Sometimes they're different. A 5% drop from 100K users (5K lost) matters more than a 20% drop from 1K users (200 lost).
@@ -366,9 +369,13 @@ A: Start with the obvious ones: device, new/returning, traffic source. Then let 
 ## Common Funnel Data Issues
 
 - **Missing events** — Event counts << page views → undercounts
+
 - **Duplicate events** — Same user/timestamp → overcounts
+
 - **Bot traffic** — Unusual patterns, data center IPs → inflates top
+
 - **Cross-device** — User appears twice → undercounts
+
 - **Session stitching** — Gaps in journey → breaks logic
 
 **Always validate data before analyzing.**
@@ -478,9 +485,13 @@ A: Don't accuse their UI. Present the data objectively. If their UI is the probl
 ## Funnel Analysis: Key Takeaways
 
 1. **Define stages with event names** — not page names, not intentions
+
 2. **Calculate both % and absolute drops** — they tell different stories
+
 3. **Segment immediately** — the insight is in the segments
+
 4. **Validate data first** — logging gaps will mislead you
+
 5. **Counter-metrics matter** — conversion isn't the only goal (AOV, fraud)
 
 <!--
@@ -778,8 +789,11 @@ A: Convenience. It's easy to implement, easy to explain, and channels like Googl
 
 If user had 4 touchpoints before a $100 conversion:
 - LinkedIn: $25
+
 - Content: $25
+
 - Email: $25
+
 - Search: $25
 
 **Bias:** Treats all touchpoints as equal, ignores timing
@@ -861,7 +875,9 @@ Typical: **40% first / 20% middle (split) / 40% last**
 
 Recognizes that:
 - First touch introduced the user (awareness)
+
 - Last touch closed the deal (conversion)
+
 - Middle touches helped but were less decisive
 
 **Popular because it feels intuitively fair.**
@@ -1024,8 +1040,11 @@ A: Focus on the top 10-20 paths by volume or value. There's a long tail of rare 
 ## Data Quality Nightmares
 
 - **Cross-device** — User on phone, converts on laptop → appears as two users
+
 - **Cookie deletion** — Privacy browsers → touchpoints disappear
+
 - **Walled gardens** — FB/Google limit data → can't see full journey
+
 - **UTM inconsistency** — Different teams → channels miscategorized
 
 Attribution is only as good as your tracking.
@@ -1136,10 +1155,15 @@ A: Acknowledge their contribution explicitly. Position it as 'Search is essentia
 ## Attribution: Key Takeaways
 
 1. **Touchpoint = user_id + timestamp + channel** — you need all three
+
 2. **No model is "right"** — present multiple, look for disagreements
+
 3. **Attribution windows matter** — be explicit about your choice
+
 4. **Path analysis reveals interactions** — channels don't work alone
+
 5. **Data quality limits everything** — cross-device and cookies kill accuracy
+
 6. **Validate with holdouts** — before major budget shifts, test causally
 
 <!--
@@ -1227,8 +1251,11 @@ If ONLY paid social on mobile has the problem, it might be both — or there's a
 **Key questions to consider:**
 
 1. How would Funnel Analysis help you here?
+
 2. How would Channel Attribution help you here?
+
 3. What if both are right — how do you untangle the effects?
+
 4. What data would you need to decide?
 
 <!--
@@ -1322,7 +1349,9 @@ A **counterfactual** is: *"What would have happened if we hadn't done X?"*
 
 **The Twin Study Analogy:**
 - Twin A takes drug → better in 3 days
+
 - Twin B takes placebo → better in 5 days
+
 - Difference (2 days) = **causal effect**
 
 **The problem in marketing:** We don't have twins. We must *construct* a comparison group.
@@ -1402,8 +1431,11 @@ A: Randomized holdout if you can plan ahead. Geo-matching for quick analysis whe
 
 Sales went up 12% during the campaign. But:
 - Economy improved
+
 - Competitor had a bad quarter
+
 - It was holiday season
+
 - New stores opened
 
 **Correlation is easy. Causation is hard.**
@@ -1736,8 +1768,11 @@ A: More data (longer campaign, more markets) or better experimental design. The 
 ## Common Pitfalls
 
 - **Control contamination** — Control sees treatment ads → geographic buffers
+
 - **Selection bias** — Best markets get campaign → randomize or match
+
 - **Pull-forward** — Sales spike then drop → measure full period
+
 - **Competitor confound** — Competitor enters control → validate matching
 
 <!--
@@ -1817,7 +1852,9 @@ A: Depends on purchase frequency. For consumer goods bought monthly, measure at 
 
 **Stakeholder complexity:**
 - CFO: Skeptical (burned by past campaign overspend)
+
 - CMO: Advocate (budget depends on proving effectiveness)
+
 - Agency: Worried (low ROI threatens $5M contract)
 
 <!--
@@ -1889,10 +1926,15 @@ A: Monitor news, check for unusual sales patterns in control markets, look for e
 ## Campaign Effectiveness: Key Takeaways
 
 1. **Correlation ≠ causation** — "sales went up" doesn't mean campaign worked
+
 2. **You need a counterfactual** — what would have happened without campaign
+
 3. **Randomized holdouts are gold standard** — plan them into future campaigns
+
 4. **Synthetic control for observational** — when you can't randomize
+
 5. **Check for pull-forward** — measure beyond campaign period
+
 6. **Report confidence intervals** — point estimates alone are misleading
 
 <!--
@@ -2116,7 +2158,9 @@ For now, just note: break down CAC by channel. The aggregate lies to you."
 
 LTV requires predicting the future:
 - How long will they stay? (Retention)
+
 - What will they spend? (Revenue)
+
 - What's your margin? (Profitability)
 
 **Simple formula:**
@@ -2298,8 +2342,11 @@ Channels don't work in isolation.
 
 What happens?
 - Brand awareness drops
+
 - Organic search volume decreases
+
 - Referral slows (fewer people know about you)
+
 - Overall growth drops 40%
 
 **Paid social was feeding the other channels.**
@@ -2413,10 +2460,15 @@ A: Run a geo-holdout test first. Cut paid social in 10-20% of markets and measur
 ## CAC/LTV: Key Takeaways
 
 1. **Use fully-loaded CAC** — include salaries, tools, creative
+
 2. **Project LTV conservatively** — extrapolation is guessing
+
 3. **Use cohort-based analysis** — track real behavior over time
+
 4. **Calculate by channel** — aggregate hides important variation
+
 5. **Channels interact** — cutting one may hurt others
+
 6. **Payback matters** — not just ratio (cash flow implications)
 
 <!--
@@ -2492,8 +2544,11 @@ These four analyses give you a complete picture of the acquisition side of the c
 
 Things don't work in isolation.
 - **Funnel:** Device handoffs (mobile browse, desktop buy)
+
 - **Attribution:** Multi-touch journeys
+
 - **Campaign:** Control market confounds
+
 - **CAC/LTV:** Channel awareness spillover
 
 **Before major decisions, test causally.** Attribution and correlation lie.

--- a/slides/block_03_retention_growth_analyses.md
+++ b/slides/block_03_retention_growth_analyses.md
@@ -43,8 +43,11 @@ Block 3 is about **keeping** and **growing** them.
 
 The analyses in this block answer:
 - Why do they leave? (Retention)
+
 - Who matters most? (Power User)
+
 - What's broken? (Failure)
+
 - How do they grow? (Expansion)
 
 <!--
@@ -133,6 +136,7 @@ A: It depends on the product category. Gaming apps: 20-30% D30 is solid. Product
 **Acquisition is expensive. Retention compounds.**
 
 - Improving acquisition 20% → 20% more users
+
 - Improving retention 20% → 20% more users **every cohort, forever**
 
 Small retention improvements have massive long-term impact.
@@ -176,7 +180,9 @@ A: Several reasons. Acquisition is more visible. Executives can see ads running.
 
 **Critical decision:** What counts as "active"?
 - App open? (low bar)
+
 - Core action? (higher bar, more meaningful)
+
 - Purchase? (highest bar)
 
 <!--
@@ -266,7 +272,9 @@ A: DN is more common for quick comparisons. Rolling is better for understanding 
 
 **Shape matters:**
 - **Steep early drop** = First-time experience problem
+
 - **Continued decline** = No habit formation
+
 - **Flattens** = Found product-market fit for those users
 
 Where the curve flattens = your "true" retention rate.
@@ -393,6 +401,7 @@ A: Start with product intuition. What do you think the 'aha moment' is? Test tha
 
 Users who add 3+ friends retain better. But:
 - Did friend-adding **cause** retention?
+
 - Or do **naturally engaged users** both add friends AND retain?
 
 If you force friend-adding on disengaged users, they might still churn.
@@ -550,9 +559,13 @@ A: Recommend a test: Show friend-adding prompts to 50% of users, suppress for 50
 ## Retention Analysis: Key Takeaways
 
 1. **Define "active" precisely** — same event across all analysis
+
 2. **DN vs. rolling retention** — be explicit about which you're using
+
 3. **Cohort comparisons reveal trends** — aggregates hide insights
+
 4. **Driver analysis is correlational** — A/B test before mandating
+
 5. **Counter-metrics matter** — don't break signup to fix D7
 
 <!--
@@ -599,8 +612,11 @@ Most products have highly skewed engagement:
 
 Power user analysis asks:
 - How concentrated is engagement?
+
 - Who are these users?
+
 - What do they do differently?
+
 - Should we optimize for them or broaden engagement?
 
 <!--
@@ -689,6 +705,7 @@ A: Yes, you can create composite scores or use multiple definitions in parallel.
 
 Often, engagement follows a power law:
 - Top 10% of users → 50%+ of engagement
+
 - Top 20% of users → 80%+ of engagement
 
 The exact numbers vary, but skew is almost universal.
@@ -792,13 +809,19 @@ Track user journeys over time:
 **Two options:**
 
 1. **Optimize for power users**
+
    - They drive most engagement
+
    - High retention, high value
+
    - Risk: Alienate casual users
 
 2. **Broaden engagement**
+
    - More users become power users
+
    - Larger addressable base
+
    - Risk: Dilute product for core users
 
 **This is a strategy decision, not an analytics one.** Your job is to inform it.
@@ -936,9 +959,13 @@ A: Personalization. Different users see different experiences based on their usa
 ## Power User Analysis: Key Takeaways
 
 1. **Engagement is usually skewed** — measure how much
+
 2. **Define "power" with a clear metric** — time, actions, or revenue
+
 3. **Profile power users behaviorally** — what do they do differently?
+
 4. **Counter-metric: casual user health** — don't alienate the majority
+
 5. **This informs strategy** — analysts provide data, leadership decides
 
 <!--
@@ -991,8 +1018,11 @@ Fifth — and this is the professional practice point: this informs strategy, it
 **Questions to consider:**
 
 1. Why might power users be unaffected while casual users suffer?
+
 2. Is this a Retention Analysis problem or a Power User Analysis problem?
+
 3. What counter-metric should have been tracked during the redesign?
+
 4. What's your hypothesis for the root cause?
 
 <!--
@@ -1049,6 +1079,7 @@ Stand up. Walk around. The last 30 minutes cover Failure and Expansion analyses.
 
 Different from other analyses:
 - **Funnel analysis** tells you *where* users drop off
+
 - **Failure analysis** tells you *why*
 
 Often **exploratory** — you don't have a hypothesis yet. You're categorizing problems.
@@ -1402,10 +1433,15 @@ A: Build a whitelist of valid brand names and product terms. A/B test with a sma
 ## Failure Analysis: Key Takeaways
 
 1. **Start with manual sampling** — you need to see the failures
+
 2. **Build a taxonomy** — 3-7 categories, mutually exclusive
+
 3. **Validate with inter-rater reliability** — if classifiers disagree, refine
+
 4. **Size by impact, not just volume** — small category can have big $$$
+
 5. **This is exploratory** — you're building hypotheses, not testing them
+
 6. **Counter-metrics prevent over-correction** — fixing one thing can break another
 
 <!--
@@ -1448,7 +1484,9 @@ Sixth: counter-metrics prevent over-correction. Fixing zero-results might break 
 
 Questions:
 - Why do free users upgrade to paid?
+
 - Why do basic subscribers upgrade to premium?
+
 - What triggers expansion (more seats, higher tier)?
 
 This is about **extracting more value from existing customers** — often cheaper than acquisition.
@@ -1492,7 +1530,9 @@ A: Expansion directly drives LTV. A customer who upgrades has higher lifetime va
 
 **Freemium math:**
 - Free users: Large base, low/no revenue
+
 - Paid users: Smaller base, meaningful revenue
+
 - Premium: Smallest base, highest revenue
 
 **The question:** What makes someone convert?
@@ -1643,6 +1683,7 @@ A: Hit rate × conversion rate = percentage of users who convert due to that lim
 Lowering limits increases conversion, but:
 
 - **Too high:** Few hit the limit, low conversion
+
 - **Too low:** Users feel nickeled-and-dimed, churn
 
 **Finding the sweet spot requires experimentation.**
@@ -1794,9 +1835,13 @@ A: Look at behavior patterns. Users who've almost hit limits and expressed frust
 ## Expansion Analysis: Key Takeaways
 
 1. **Conversion drivers are behavioral** — what triggers the upgrade moment?
+
 2. **Limits are powerful but dangerous** — too aggressive alienates users
+
 3. **Targeting requires validation** — holdout tests before aggressive prompts
+
 4. **Counter-metric: free user health** — don't kill the funnel to boost conversion
+
 5. **Selection bias is real** — engaged users ≠ incremental conversions
 
 <!--
@@ -1839,7 +1884,9 @@ This is the same pattern we saw in retention driver analysis. Correlation-based 
 
 Questions:
 - Do our products complement each other (1+1=3)?
+
 - Or cannibalize each other (1+1=1.5)?
+
 - Should we invest in cross-product features?
 
 Relevant for: Multi-product companies, platform businesses, feature suites.
@@ -1918,6 +1965,7 @@ You observe: Users of both Product A and B retain 40% better than single-product
 
 **But:** Is that because:
 1. Using both products **causes** higher retention? (Complement)
+
 2. Highly engaged users **naturally** use more products? (Selection bias)
 
 If it's selection bias, pushing cross-product adoption won't help — and may annoy users.
@@ -2024,7 +2072,9 @@ A: Very common. Almost every multi-product company I've seen has done this analy
 
 **Counter-metrics:**
 - Individual product focus (dilution risk)
+
 - User overwhelm (too many cross-promos)
+
 - Cannibalization (one product grows at another's expense)
 
 **Pre-mortem:** We found 40% better retention for multi-product users and invested heavily in cross-product features. But it was selection bias — engaged users adopt everything naturally. Cross-product prompts annoyed single-product users, and FriendFeed DAU dropped 10%.
@@ -2068,9 +2118,13 @@ A: Holdout test. Suppress cross-product prompts for 20% of users. If prompted us
 ## Ecosystem Analysis: Key Takeaways
 
 1. **Multi-product correlation ≠ causation** — selection bias is likely
+
 2. **Use natural experiments** — outages reveal true dependence
+
 3. **Holdout test before investing** — don't assume cross-product features help
+
 4. **Watch for cannibalization** — products may compete internally
+
 5. **This informs platform strategy** — big investment decisions
 
 <!--
@@ -2124,7 +2178,9 @@ That's ecosystem analysis. It shares the selection bias lesson with retention, p
 **Multiple analyses today shared this trap:**
 
 - Retention drivers: Engaged users do everything
+
 - Power users: They were always going to be power users
+
 - Expansion: High-propensity users would convert anyway
 
 **Solution:** A/B test before major investments. Correlation ≠ causation.
@@ -2163,7 +2219,9 @@ A: If the intervention is cheap and reversible, sometimes you just try it. But f
 
 You now know:
 - **The Analytics Project Brief framework** (10 sections)
+
 - **Counter-metrics and adversarial thinking**
+
 - **9 foundational analyses** (4 acquisition + 5 retention/growth)
 
 **Day 2:** Stakeholders & Influence, then Application & Capstone Preparation.
@@ -2178,6 +2236,7 @@ You now know:
 **Day 2 starts at 10:50**
 
 - Block 4: Application & Practice
+
 - Block 5: Stakeholders & Influence
 
 **Before then:** Review the Brief template. Questions: rubiae@ceu.edu

--- a/slides/block_04_application_practice.md
+++ b/slides/block_04_application_practice.md
@@ -292,7 +292,9 @@ Now let's see how they **connect** in a complete, realistic example.
 
 We'll walk through one Brief end-to-end and discuss:
 - What makes it strong?
+
 - What would you change?
+
 - How do sections reference each other?
 
 <!--
@@ -398,7 +400,9 @@ Also notice the hypothesis is quantified. Not 'organic is better than paid' but 
 **Counter-Metrics:**
 
 - **Growth rate** (Tradeoff) — Cutting unprofitable channels slows growth
+
 - **Engagement quality** (Guardrail) — Cheap users may not engage
+
 - **Brand awareness** (Tradeoff) — Paid builds awareness even with low direct ROI
 
 **Discussion:** Why is growth rate a "tradeoff" not a "guardrail"?
@@ -537,12 +541,16 @@ A: Common approach: proportional to headcount or time tracking. Perfect accuracy
 
 **In Scope:**
 - 5 channels (Paid Social, Paid Search, Organic, Referral, Influencer)
+
 - Cohorts from last 18 months
+
 - Monthly and annual subscribers
 
 **Out of Scope:**
 - Free tier users
+
 - B2B partnerships
+
 - Reactivated churned users
 
 **Discussion:** Why exclude free tier users? Is that the right call?
@@ -728,8 +736,11 @@ A: The pre-mortem is written BEFORE the analysis. The example shows what could g
 The Brief isn't 10 independent sections. They reference each other:
 
 - **Methodology** must answer the **Problem**
+
 - **Counter-metrics** anticipate **Pre-mortem** scenarios
+
 - **Stakeholder blockers** inform **how you present findings**
+
 - **Decision criteria** prevent analysis-paralysis
 
 <!--
@@ -758,9 +769,13 @@ On your assignment, this is where most points are lost. Sections that feel disco
 ## What Makes This Brief Strong?
 
 1. **Specific metric definition** — Not just "LTV:CAC" but fully specified
+
 2. **Counter-metrics with types** — Guardrail vs. tradeoff is clear
+
 3. **Named blocker with motivation** — "Jobs on the line" is concrete
+
 4. **Decision criteria include null result** — What if we find nothing?
+
 5. **Pre-mortem is specific** — Not generic "something went wrong"
 
 <!--
@@ -839,7 +854,9 @@ You'll see 3 business scenarios.
 
 For each one:
 1. **Which foundational analyses apply?** (Pick 2-3)
+
 2. **Why those analyses?** (Justify your choice)
+
 3. **What's the primary metric?** (Be specific)
 
 Work in groups of 3-4. You'll present and defend your choices.
@@ -1094,8 +1111,11 @@ There's no single "right" answer to analysis selection.
 
 It depends on:
 - **What data is available**
+
 - **What decisions need to be made**
+
 - **What's the timeline**
+
 - **What's been tried before**
 
 The Brief framework forces you to **justify** your choice, not just make it.
@@ -1167,7 +1187,9 @@ Ready?"
 
 Write these sections:
 1. **Primary Metric** — Full operational definition (2 min)
+
 2. **One Counter-Metric** — Label as Guardrail or Tradeoff, explain why it could break (3 min)
+
 3. **One Blocker** — Name the role, their motivation to resist, and your mitigation (3 min)
 
 **Work alone. Timer starts now.**
@@ -1351,7 +1373,9 @@ The test: Who has veto power over acting on your findings? Who might resist? Why
 
 **Warning signs:**
 - "While we're at it..."
+
 - "It would be easy to also..."
+
 - "Leadership asked if we could add..."
 
 **The test:** Does adding this help the decision we're trying to inform? If not, it's out of scope.

--- a/slides/block_05_influence.md
+++ b/slides/block_05_influence.md
@@ -56,7 +56,9 @@ I know some of you are thinking 'this isn't technical.' You're right. It's not. 
 
 The best analysis fails if:
 - The wrong people see it
+
 - The right people don't buy in
+
 - A blocker kills it politically
 
 **Technical correctness is necessary but not sufficient.**
@@ -206,10 +208,12 @@ Beyond the grid, identify:
 
 **Champions:** Who actively wants this to succeed?
 - They'll advocate in meetings you're not in
+
 - They'll provide air cover when things get political
 
 **Blockers:** Who might resist?
 - **Why** do they resist? (Budget? Ego? Workload? Past failures?)
+
 - Understanding motivation enables mitigation
 
 <!--
@@ -312,9 +316,13 @@ Let me hear from a few of you. You — which analysis and who's in High Power, H
 ## Stakeholder Management: Key Takeaways
 
 1. **Map stakeholders to Power-Interest grid** — different strategies per quadrant
+
 2. **Identify champions and blockers** — understand *why* blockers resist
+
 3. **Pre-brief uncomfortable findings** — never ambush in meetings
+
 4. **Tailor communication by quadrant** — executives ≠ ICs
+
 5. **Politics is part of the job** — technical correctness isn't enough
 
 <!--
@@ -397,7 +405,9 @@ A: Only if it's actually shallow. You can be rigorous AND simple. The methodolog
 
 **Research shows:**
 - Simple explanations are rated as more credible
+
 - Jargon reduces persuasion (even with expert audiences)
+
 - Visual clarity increases agreement
 
 Complex ≠ Rigorous. Complex = Hard to trust.
@@ -469,8 +479,11 @@ Here's the rule: if an executive can't understand it in 30 seconds, simplify. If
 Before presenting, ask:
 
 1. **Can I explain this in one sentence?**
+
 2. **Would my non-technical friend understand?**
+
 3. **What's the ONE number that matters?**
+
 4. **Is everything else supporting detail?**
 
 If you can't pass this test, you're not ready to present.
@@ -598,7 +611,9 @@ Most successful presentations use 2-3 strategies combined. Let me walk you throu
 
 **When to use:**
 - Stakeholder respects hierarchy
+
 - You have genuine top-down support
+
 - Decision needs organizational weight
 
 <!--
@@ -627,7 +642,9 @@ The danger: don't fake it. If you say 'the VP supports this' and the VP hasn't a
 You probably don't have inherent authority. So:
 
 1. **Get a sponsor** — Find a leader who supports your work
+
 2. **Secure explicit endorsement** — "Can I say you've reviewed this?"
+
 3. **Cite the ask** — "This was requested by [leader]"
 
 **Warning:** Don't fake authority. Being caught undermines everything.
@@ -665,7 +682,9 @@ The warning is important: don't fake it. Don't say 'the CEO supports this' if yo
 
 **When to use:**
 - Stakeholder is technical or detail-oriented
+
 - Your personal credibility isn't established yet
+
 - The methodology is complex or novel
 
 <!--
@@ -692,8 +711,11 @@ This is the natural strategy for junior analysts. You might not have authority o
 ## Credibility: How to Build It
 
 1. **Get peer review** — Have respected ICs review your work
+
 2. **Cite precedent** — "This is the same approach Airbnb used for..."
+
 3. **Show your work** — Make methodology transparent and available
+
 4. **Acknowledge limitations** — Credible people admit uncertainty
 
 **Warning:** Over-claiming expertise you don't have destroys credibility permanently.
@@ -734,7 +756,9 @@ The warning: don't over-claim expertise. If you claim to be an expert in somethi
 
 **When to use:**
 - Stakeholder is risk-averse
+
 - Decision feels uncertain
+
 - You have relevant data or benchmarks
 
 <!--
@@ -763,8 +787,11 @@ And obviously useful when you have the data. Survey results, benchmarks, competi
 ## Social Proof: How to Build It
 
 1. **Survey data** — What do users/customers actually say?
+
 2. **Industry benchmarks** — What do peers do?
+
 3. **Internal precedent** — "We did something similar for X product"
+
 4. **Competitive intelligence** — What are competitors doing?
 
 **Warning:** Cherry-picked social proof backfires. Be honest about what the data shows.
@@ -808,7 +835,9 @@ A: Then don't force it. Use a different strategy. Weak social proof is worse tha
 
 **When to use:**
 - Stakeholder has stated priorities or values
+
 - Organization has clear strategy
+
 - You can draw genuine connection
 
 <!--
@@ -837,8 +866,11 @@ The key word is genuine. If you force a connection that isn't there, it feels ma
 ## Consistency: How to Build It
 
 1. **Know the roadmap** — What has leadership committed to?
+
 2. **Quote back priorities** — "You mentioned [X] was important..."
+
 3. **Show alignment** — Make the connection explicit
+
 4. **Avoid contradictions** — Don't recommend things that conflict with stated goals
 
 **Warning:** Forced connections feel manipulative. The alignment must be genuine.
@@ -946,8 +978,11 @@ CFOs often respond to data and financial alignment more than authority.
 ## The Wrong Strategy Backfires
 
 - **Technical expert** + Authority → *"Show me the math"*
+
 - **Senior executive** + Excessive detail → *"I don't have time"*
+
 - **Risk-averse PM** + Novelty framing → *"Too risky"*
+
 - **Data-driven leader** + Anecdotes only → *"Where's the evidence?"*
 
 **Know your audience.** The wrong strategy is worse than no strategy.
@@ -1038,8 +1073,11 @@ Champions advocate for you in rooms you're not in.
 
 **Give them:**
 1. **The one-sentence summary** — What they'll say when asked
+
 2. **The killer stat** — The number that makes the case
+
 3. **Anticipated objections + responses** — So they can defend
+
 4. **Your recommendation clearly** — So they don't misrepresent
 
 <!--
@@ -1120,10 +1158,15 @@ A: You might not. But you've reduced their opposition and shown respect. Even if
 Before any major presentation:
 
 1. **Identify who might be uncomfortable**
+
 2. **Schedule 15-min 1:1** — "I want to get your input before the meeting"
+
 3. **Share key findings** — No surprises
+
 4. **Solicit feedback** — "What am I missing?"
+
 5. **Incorporate reasonable feedback** — Shows you listened
+
 6. **In the meeting** — They're prepared, not ambushed
 
 This transforms blockers into (at worst) neutrals.
@@ -1170,10 +1213,15 @@ A: Better to know now than in the meeting. If they're hostile privately, you hav
 
 **Pre-brief approach:**
 - Meet privately before presentation
+
 - Frame: "I want to understand your perspective"
+
 - Share findings early
+
 - Ask: "What am I missing about how Search contributes?"
+
 - Incorporate valid points
+
 - In meeting: "As [name] and I discussed, there are tradeoffs here..."
 
 <!--
@@ -1379,9 +1427,13 @@ One more. Anyone suggest pre-briefing the PM before the meeting?
 ## Debrief: What Makes Influence Work
 
 1. **Know your audience** — One person, not "the team"
+
 2. **Have a clear recommendation** — Specific action
+
 3. **Choose strategies based on stakeholder** — Not one-size-fits-all
+
 4. **Pre-brief blockers** — Never surprise
+
 5. **Make it easy to understand** — Processing fluency
 
 Influence isn't manipulation. It's clear communication + stakeholder awareness.

--- a/slides/block_06_capstone_closing.md
+++ b/slides/block_06_capstone_closing.md
@@ -194,9 +194,13 @@ Here's the connection to this course: all three require a well-scoped project. I
 Each Brief section maps to a capstone question:
 
 - **Problem & Decision** → What question are you answering?
+
 - **Metrics** → How will you measure success?
+
 - **Stakeholders** → Who is your sponsor?
+
 - **Methodology** → What analyses will you run?
+
 - **Scope** → What's in and out?
 
 <!--
@@ -337,8 +341,11 @@ The Brief forces you to address all of these before you start. That's why we fil
 
 Your sponsor is your primary stakeholder. They:
 - Define the business problem
+
 - Provide access to data
+
 - Give feedback on approach
+
 - Validate findings make sense
 
 **Ideal sponsor:** Someone with a real question AND time to engage.
@@ -390,8 +397,11 @@ If you haven't started yet, **start today.**
 
 Why early matters:
 - Good projects get claimed
+
 - Building relationships takes time
+
 - Data access takes time
+
 - Scope negotiation takes time
 
 March 16 is your assignment deadline. That's 9 weeks away.
@@ -430,9 +440,13 @@ March 16 is your deadline. That's 9 weeks away. 9 weeks is not a lot of time for
 ## Where to Find Projects
 
 - **Your employer** — Know the data (but may be narrow)
+
 - **CEU network** — Curated, committed sponsors (competitive)
+
 - **Personal network** — Relationship exists (quality varies)
+
 - **Cold outreach** — Unlimited options (low response)
+
 - **Nonprofits/NGOs** — Meaningful work (less data sophistication)
 
 **Best approach:** Multiple channels simultaneously.
@@ -469,8 +483,11 @@ Best approach: pursue multiple channels simultaneously. Don't wait to hear back 
 Most projects come through relationships. Activate your network:
 
 1. **LinkedIn post** — "Looking for analytics capstone project for [school/program]"
+
 2. **Email to contacts** — Personal ask to former colleagues, managers
+
 3. **Alumni network** — CEU alumni who've done capstones
+
 4. **Professional groups** — Meetups, Slack communities
 
 **The ask:** "Do you know anyone with a data question they'd like help with?"
@@ -587,12 +604,16 @@ Sponsors often want **more** than is feasible.
 
 **Your job:** Negotiate a scope that's:
 - Valuable to them
+
 - Feasible for you
+
 - Demonstrable as a capstone
 
 **How:**
 - "What's the most important question?"
+
 - "If we could only answer one thing, what would it be?"
+
 - "What would you do with the answer?"
 
 <!--
@@ -636,7 +657,9 @@ Use these questions. They're magic."
 
 **Key moves:**
 - Acknowledge their big goal
+
 - Propose a specific slice
+
 - Check if it's valuable
 
 <!--
@@ -725,9 +748,13 @@ Take 2 minutes. Would you take this project? What questions would you ask before
 
 **What you'll receive:** A unique 2-page business scenario describing:
 - A company and its situation
+
 - A business problem
+
 - Key stakeholders
+
 - Available data
+
 - Constraints
 
 **What you'll submit:** A complete Analytics Project Brief for that scenario.
@@ -764,8 +791,11 @@ Each student receives a **different scenario**.
 
 This is intentional:
 - Prevents copying
+
 - Forces independent thinking
+
 - Creates variety for class discussion
+
 - Mirrors real-world (you don't get the same problem as a colleague)
 
 Your scenario will be distributed via email after class today.
@@ -1025,13 +1055,18 @@ This is where most points are lost. Two parts:
 
 **Internal Consistency (10 pts):**
 - Do your metrics align with your methodology?
+
 - Does your pre-mortem connect to your risks and stakeholders?
+
 - Do decision criteria match your problem statement?
+
 - Does scope match the timeline and data you have?
 
 **Professional Quality (10 pts):**
 - Clear, concise writing
+
 - Would you present this to a real sponsor?
+
 - No contradictions between sections
 
 <!--
@@ -1068,10 +1103,15 @@ If your Brief reads like 10 separate documents pasted together, you'll lose poin
 ## Process Recommendation
 
 1. **Read the scenario twice** — First for overview, second for details
+
 2. **Identify the core decision** — What will this analysis inform?
+
 3. **Draft the metric first** — Forces precision early
+
 4. **Work through stakeholders** — Who might block? Why?
+
 5. **Select methodology** — Which 2-3 analyses apply?
+
 6. **Write the pre-mortem last** — After you understand the full picture
 
 <!--
@@ -1415,8 +1455,11 @@ But the **discipline of scoping projects well** is durable.
 
 In 10 years:
 - You may not remember SQL syntax
+
 - You will remember to ask "what breaks if we succeed?"
+
 - You will remember to identify blockers before presenting
+
 - You will remember to scope before analyzing
 
 **That's what this course is for.**
@@ -1484,12 +1527,16 @@ This creates closure and reinforces learning through verbalization.
 
 **Upcoming:**
 - Scenario email: Today
+
 - Assignment due: January 16
+
 - Exam: January 27
+
 - Weekly write-ups: Jan 23 – Feb 27 (6 weeks)
 
 **Contact:**
 - rubiae@ceu.edu
+
 - Office hours by appointment
 
 <!--


### PR DESCRIPTION
This PR considers a fix for the slides markdown file lists' printing to pdf. Up to know, both the markdown and htmls files offered no readable pdf printing. I think it's beneficial for future students to have at least one option to export the slides to a portable format, like pdf.

Pandoc renders tight markdown lists (no blank lines between items) without paragraph wrapping, causing list items to lose vertical spacing in PDF output. All lists across the 7 slide decks were tight.

**Before (tight):**

```
- Wrong problem — solved something nobody needed
- Wrong metric — optimized the wrong thing
- Wrong stakeholders — built it, nobody used it
```

Pandoc emits `<li>text</li>` → items cramped together in PDF.

**After (loose):**

```
- Wrong problem — solved something nobody needed

- Wrong metric — optimized the wrong thing

- Wrong stakeholders — built it, nobody used it
```

Pandoc emits `<li><p>text</p></li>` → proper paragraph spacing per item.

    * 285 blank lines added across all 7 `slides/block_*.md` files — zero content modifications

    * HTML comments (instructor notes) left untouched

    * Handles nested lists, numbered lists, and continuation text correctly